### PR TITLE
update send.py

### DIFF
--- a/send.py
+++ b/send.py
@@ -1,13 +1,27 @@
+# If you just call using python udpSendXPackets.py, will default to 1k sends, 10.0.0.8 ip, 5005 as port.
+# If you call with multiple args: 
+#first arg = packets sent 
+#second arg = ip to send to,
+#third arg = port.
+
 import socket
 import sys
 
-if len(sys.argv) < 2: 
-	exit("An integer command-line argument specifies how many packets to send.")
+args = len(sys.argv) #get the number of args passed in. This is the list length, the first
+					 #item in the list will always be the name.
 
-tosend = int(sys.argv[1])
-
-UDP_IP = "10.0.0.8"  # Receiver's IP address
-UDP_PORT = 5005
+if args < 2: 
+	tosend = 1000
+else:
+	tosend = int(sys.argv[1])
+if args < 3:
+	UDP_IP = "10.0.0.8" # default ip address
+else:
+	UDP_IP = str(sys.argv[2]) #recievers ip address
+if args < 4:
+	UDP_PORT = 5005 # default port
+else:
+	UDP_PORT = int(sys.argv[3]) # port to use.
 MESSAGE = "Packet number "
 
 print "UDP target IP:", UDP_IP


### PR DESCRIPTION
add optional arguments from file line. call python send.py to send 1k to ip 10.0.0.8 and port 5005. If you want to change arguments:

first argument is amount of packets to send, second argument is ip address to send to, third argument is port to use.

To use the second argument, you must include the first argument. If you want to change the port, you must name the first two arguments.